### PR TITLE
Function Renames And Increased Efficiency of Making QCores

### DIFF
--- a/DataFormats/Phase2TrackerDigi/interface/QCore.h
+++ b/DataFormats/Phase2TrackerDigi/interface/QCore.h
@@ -5,7 +5,7 @@
 class QCore{
 
  private:
-  std::vector<int> adcs;
+  std::vector<int> adcs_;
   bool islast_;
   bool isneighbour_;
   int rocid_;
@@ -15,11 +15,11 @@ class QCore{
  public:
   QCore(
 	int rocid,
-	int ccol_in,
-	int qcrow_in,
-	bool isneighbour_in,
-	bool islast_in,
-	std::vector<int> adcs_in
+	int ccol,
+	int qcrow,
+	bool isneighbour,
+	bool islast,
+	std::vector<int> adcs
 	);
 
   QCore() {

--- a/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
+++ b/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
@@ -26,7 +26,7 @@ public:
 	std::vector<bool> getChipCode();
 
 private:
-	std::pair<int,int> get_QCore_pos(Hit hit);
+	std::pair<int,int> getQCorePos(Hit hit);
 
 	QCore getQCoreFromHit(Hit pixel);
 

--- a/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
+++ b/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
@@ -28,7 +28,7 @@ public:
 private:
 	std::pair<int,int> get_QCore_pos(Hit hit);
 
-	QCore get_QCore_from_hit(Hit pixel);
+	QCore getQCoreFromHit(Hit pixel);
 
 	std::vector<QCore> rem_duplicates(std::vector<QCore> qcores);
 

--- a/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
+++ b/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
@@ -30,7 +30,7 @@ private:
 
 	QCore getQCoreFromHit(Hit pixel);
 
-	std::vector<QCore> rem_duplicates(std::vector<QCore> qcores);
+	//std::vector<QCore> rem_duplicates(std::vector<QCore> qcores);
 
 	std::vector<QCore> organize_QCores(std::vector<QCore> qcores);
 };

--- a/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
+++ b/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
@@ -23,7 +23,7 @@ public:
 
 	std::vector<QCore> getOrganizedQCores();
 
-	std::vector<bool> get_chip_code();
+	std::vector<bool> getChipCode();
 
 private:
 	std::pair<int,int> get_QCore_pos(Hit hit);

--- a/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
+++ b/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
@@ -30,8 +30,6 @@ private:
 
 	QCore getQCoreFromHit(Hit pixel);
 
-	//std::vector<QCore> rem_duplicates(std::vector<QCore> qcores);
-
 	std::vector<QCore> organize_QCores(std::vector<QCore> qcores);
 };
 

--- a/DataFormats/Phase2TrackerDigi/src/QCore.cc
+++ b/DataFormats/Phase2TrackerDigi/src/QCore.cc
@@ -19,13 +19,13 @@
     {
     };*/
 
-QCore::QCore(int rocid, int ccol_in, int qcrow_in, bool isneighbour_in, bool islast_in, std::vector<int> adcs_in) {
+QCore::QCore(int rocid, int ccol, int qcrow, bool isneighbour, bool islast, std::vector<int> adcs) {
   rocid_ = rocid;
-  ccol_ = ccol_in;
-  qcrow_ = qcrow_in;
-  isneighbour_ = isneighbour_in;
-  islast_ = islast_in;
-  adcs = adcs_in;
+  ccol_ = ccol;
+  qcrow_ = qcrow;
+  isneighbour_ = isneighbour;
+  islast_ = islast;
+  adcs_ = adcs;
 }
 
 //Takes in a hitmap in sensor corrdinates with 4x4 regions and converts it to readout chip coordinates with 2x8 regions
@@ -61,7 +61,7 @@ std::vector<bool> QCore::getHitmap() {
 	std::vector<bool> hitmap = {};
 
     	//hitmap.reserve(16);
-    	for(auto adc : adcs) {
+    	for(auto adc : adcs_) {
         	hitmap.push_back(adc > 0);
     	}
 	//assert(hitmap.size()==16);
@@ -156,7 +156,7 @@ std::vector<bool> QCore::encodeQCore(bool is_new_col) {
 	std::vector<bool> hitmap_code = getHitmapCode(getHitmap());
 	code.insert(code.end(), hitmap_code.begin(), hitmap_code.end());
 
-	for(auto adc : adcs) {
+	for(auto adc : adcs_) {
 		if(adc != 0) {
 			std::vector<bool> adc_code = intToBinary(adc, 4);
 			code.insert(code.end(), adc_code.begin(), adc_code.end());

--- a/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
+++ b/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
@@ -25,7 +25,7 @@ std::pair<int,int> ReadoutChip::get_QCore_pos(Hit hit) {
 }
 
 //Takes in a hit and returns the 4x4 QCore that hit is a part of
-QCore ReadoutChip::get_QCore_from_hit(Hit pixel) {
+QCore ReadoutChip::getQCoreFromHit(Hit pixel) {
         std::vector<int> adcs =
                 {0,0,0,0,
 		0,0,0,0,
@@ -123,7 +123,7 @@ std::vector<QCore> ReadoutChip::getOrganizedQCores() {
         std::vector<QCore> qcores = {};
 
         for(const auto& hit:hitList) {
-                qcores.push_back(get_QCore_from_hit(hit));
+                qcores.push_back(getQCoreFromHit(hit));
         }
 
         return link_QCores(organize_QCores(rem_duplicates(qcores)));

--- a/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
+++ b/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
@@ -46,26 +46,6 @@ QCore ReadoutChip::getQCoreFromHit(Hit pixel) {
         return qcore;
 }
 
-/*
-//Removes duplicates from the given list of qcores
-std::vector<QCore> ReadoutChip::rem_duplicates(std::vector<QCore> qcores) {
-        std::vector<QCore> list = {};
-
-        while(qcores.size() > 0) {
-                for(size_t i = 1; i < qcores.size(); i++) {
-                        if(qcores[i].ccol() == qcores[0].ccol() && qcores[i].qcrow() == qcores[0].qcrow()) {
-                                qcores.erase(qcores.begin() + i);
-                        }
-                }
-
-                list.push_back(qcores[0]);
-                qcores.erase(qcores.begin());
-        }
-
-        return list;
-}
-*/
-
 //Returns a list of the qcores with hits arranged by increasing column then row numbers
 std::vector<QCore> ReadoutChip::organize_QCores(std::vector<QCore> qcores) {
         std::vector<QCore> organized_list = {};
@@ -118,20 +98,6 @@ std::vector<QCore> link_QCores(std::vector<QCore> qcores) {
 
 	return qcores;
 }
-
-/*
-//Takes in list of hits and organizes them into the 4x4 QCores that contains them
-std::vector<QCore> ReadoutChip::getOrganizedQCores() {
-  std::cout << "In getOrganizedQCores" <<std::endl;
-        std::vector<QCore> qcores = {};
-
-        for(const auto& hit:hitList) {
-                qcores.push_back(getQCoreFromHit(hit));
-        }
-
-        return link_QCores(organize_QCores(rem_duplicates(qcores)));
-}
-*/
 
 //Takes in list of hits and organizes them into the 4x4 QCores that contains them
 std::vector<QCore> ReadoutChip::getOrganizedQCores() {

--- a/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
+++ b/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
@@ -130,7 +130,7 @@ std::vector<QCore> ReadoutChip::getOrganizedQCores() {
 }
 
 //Returns the encoding of the readout chip
-std::vector<bool> ReadoutChip::get_chip_code() {
+std::vector<bool> ReadoutChip::getChipCode() {
         std::vector<bool> code = {};
 
         if(hitList.size() > 0) {

--- a/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
+++ b/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
@@ -16,7 +16,7 @@ unsigned int ReadoutChip::size() {
 }
 
 //Returns the position (row,col) of the 4x4 QCore that contains a given hit
-std::pair<int,int> ReadoutChip::get_QCore_pos(Hit hit) {
+std::pair<int,int> ReadoutChip::getQCorePos(Hit hit) {
 
         int row = hit.row() / 4;
         int col = hit.col() / 4;
@@ -32,10 +32,10 @@ QCore ReadoutChip::getQCoreFromHit(Hit pixel) {
                 0,0,0,0,
 		0,0,0,0};
 
-        std::pair<int,int> pos = get_QCore_pos(pixel);
+        std::pair<int,int> pos = getQCorePos(pixel);
 
         for(const auto& hit:hitList) {
-                if(get_QCore_pos(hit) == pos) {
+                if(getQCorePos(hit) == pos) {
                         int i = (4 * (hit.row() % 4) + (hit.col() % 4) + 8) % 16;
                         adcs[i] = hit.adc();
                 }

--- a/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
+++ b/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
@@ -46,6 +46,7 @@ QCore ReadoutChip::getQCoreFromHit(Hit pixel) {
         return qcore;
 }
 
+/*
 //Removes duplicates from the given list of qcores
 std::vector<QCore> ReadoutChip::rem_duplicates(std::vector<QCore> qcores) {
         std::vector<QCore> list = {};
@@ -63,6 +64,7 @@ std::vector<QCore> ReadoutChip::rem_duplicates(std::vector<QCore> qcores) {
 
         return list;
 }
+*/
 
 //Returns a list of the qcores with hits arranged by increasing column then row numbers
 std::vector<QCore> ReadoutChip::organize_QCores(std::vector<QCore> qcores) {
@@ -117,6 +119,7 @@ std::vector<QCore> link_QCores(std::vector<QCore> qcores) {
 	return qcores;
 }
 
+/*
 //Takes in list of hits and organizes them into the 4x4 QCores that contains them
 std::vector<QCore> ReadoutChip::getOrganizedQCores() {
   std::cout << "In getOrganizedQCores" <<std::endl;
@@ -127,6 +130,32 @@ std::vector<QCore> ReadoutChip::getOrganizedQCores() {
         }
 
         return link_QCores(organize_QCores(rem_duplicates(qcores)));
+}
+*/
+
+//Takes in list of hits and organizes them into the 4x4 QCores that contains them
+std::vector<QCore> ReadoutChip::getOrganizedQCores() {
+  std::cout << "In getOrganizedQCores" <<std::endl;
+        std::vector<QCore> qcores = {};
+	bool qcore_already_exists;
+	std::pair<int,int> qcore_pos;
+
+        for(const auto& hit:hitList) {
+		qcore_already_exists = false;
+		qcore_pos = getQCorePos(hit);
+
+		for(size_t i = 0; i < qcores.size(); i++) {
+			if(qcores[i].qcrow() == qcore_pos.first && qcores[i].ccol() == qcore_pos.second) {
+				qcore_already_exists = true;
+			}
+		}
+
+		if(!qcore_already_exists) {
+                	qcores.push_back(getQCoreFromHit(hit));
+		}
+        }
+
+        return link_QCores(organize_QCores(qcores));
 }
 
 //Returns the encoding of the readout chip

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/PixelQCoreProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/PixelQCoreProducer.cc
@@ -193,7 +193,7 @@ std::vector<ReadoutChip> processHits(std::vector<Hit> hitList) {
 
         for(size_t i = 0; i < chips.size(); i++) {
                 ReadoutChip chip = chips[i];
-                code = chip.get_chip_code();
+                code = chip.getChipCode();
 
                 std::cout << "number of hits: " << chip.size() << "\n";
                 std::cout << "code length: " << code.size() << "\n";
@@ -294,7 +294,7 @@ void PixelQCoreProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
 	DetSetQCores.push_back(qcore);
       }
 
-      ROCBitStream aROCBitStream(i,chip.get_chip_code());
+      ROCBitStream aROCBitStream(i,chip.getChipCode());
 
       DetSetBitStream.push_back(aROCBitStream);
 

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/PixelQCoreProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/PixelQCoreProducer.cc
@@ -153,6 +153,16 @@ std::vector<Hit> adjustEdges(std::vector<Hit> hitList) {
         return hitListTwo;
 }
 
+std::vector<Hit> invertHits(std::vector<Hit>& hitList) {
+	std::vector<Hit> inverted_hitlist = {};
+
+	for(auto hit:hitList) {
+		inverted_hitlist.push_back(Hit(1343 - hit.row(), 431 - hit.col(), hit.adc()));
+	}
+
+	return inverted_hitlist;
+}
+
 std::vector<ReadoutChip> splitByChip(std::vector<Hit> hitList) {
         std::vector<Hit> chip1 = {};
         std::vector<Hit> chip2 = {};
@@ -175,7 +185,7 @@ std::vector<ReadoutChip> splitByChip(std::vector<Hit> hitList) {
                 }
         }
 
-        return {ReadoutChip(0,chip1), ReadoutChip(1, chip2), ReadoutChip(2, chip3),ReadoutChip(3, chip4)};
+        return {ReadoutChip(0,chip1), ReadoutChip(1, chip2), ReadoutChip(2, invertHits(chip3)),ReadoutChip(3, invertHits(chip4))};
 }
 
 std::vector<ReadoutChip> processHits(std::vector<Hit> hitList) {


### PR DESCRIPTION
#### PR description:

Renamed functions to match CMS naming conventions and changed the function used for retrieving the QCores so that it no longer creates duplicates which need to be removed

#### PR validation:

Tested that code compiled and ran successfully and confirmed by running simple test cases that QCores were still being created properly

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
