### PR TITLE
Combining hits on edges of chips

### DIFF
--- a/DataFormats/Phase2TrackerDigi/interface/Hit.h
+++ b/DataFormats/Phase2TrackerDigi/interface/Hit.h
@@ -1,14 +1,9 @@
-#ifndef HIT_H
-#define HIT_H
+#ifndef DataFormats_Phase2TrackerDigi_Hit_h
+#define DataFormats_Phase2TrackerDigi_Hit_h
 
 class Hit {
-	private:
-		int row_;
-		int col_;
-		int adc_;
-
 	public:
-		Hit(int row_num, int col_num, int adc_num);
+		Hit(int row, int col, int adc);
 
 		int row() const {
 			return row_;
@@ -23,6 +18,12 @@ class Hit {
 		}
 
 		void addADC(int adc);
+
+	private:
+		int row_;
+		int col_;
+		int adc_;
+
 };
 
 #endif

--- a/DataFormats/Phase2TrackerDigi/interface/Hit.h
+++ b/DataFormats/Phase2TrackerDigi/interface/Hit.h
@@ -21,6 +21,8 @@ class Hit {
 		int adc() const {
 			return adc_;
 		}
+
+		void addADC(int adc);
 };
 
 #endif

--- a/DataFormats/Phase2TrackerDigi/interface/QCore.h
+++ b/DataFormats/Phase2TrackerDigi/interface/QCore.h
@@ -1,16 +1,8 @@
-#ifndef QCORE_H
-#define QCORE_H
+#ifndef DataFormats_Phase2TrackerDigi_QCore_h
+#define DataFormats_Phase2TrackerDigi_QCore_h
 #include<vector>
 
 class QCore{
-
- private:
-  std::vector<int> adcs_;
-  bool islast_;
-  bool isneighbour_;
-  int rocid_;
-  int ccol_;
-  int qcrow_;
 
  public:
   QCore(
@@ -71,6 +63,13 @@ class QCore{
 
 
  private:
+  std::vector<int> adcs_;
+  bool islast_;
+  bool isneighbour_;
+  int rocid_;
+  int ccol_;
+  int qcrow_;
+
   std::vector<bool> toRocCoordinates(std::vector<bool>& hitmap);
 
   std::vector<bool> intToBinary(int num, int length);

--- a/DataFormats/Phase2TrackerDigi/interface/ROCBitStream.h
+++ b/DataFormats/Phase2TrackerDigi/interface/ROCBitStream.h
@@ -18,11 +18,11 @@ class ROCBitStream{
     rocid_ = -1;; 
   }
 
-  int get_rocid() const {
+  int rocid() const {
     return rocid_;
   }
 
-  const std::vector<bool>& get_bitstream() const {
+  const std::vector<bool>& bitstream() const {
     return bitstream_;
   }
 

--- a/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
+++ b/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
@@ -1,5 +1,5 @@
-#ifndef READOUTCHIP_H
-#define READOUTCHIP_H
+#ifndef DataFormats_Phase2TrackerDigi_ReadoutChip_h
+#define DataFormats_Phase2TrackerDigi_ReadoutChip_h
 
 #include <vector>
 #include <utility>
@@ -8,11 +8,9 @@
 #include "Hit.h"
 
 class ReadoutChip {
-	std::vector<Hit> hitList;
-	int rocnum_;
 
 public:
-	ReadoutChip(int rocnum, std::vector<Hit> hl);
+	ReadoutChip(int rocnum, std::vector<Hit> hitList);
 
 	//Returns the number of hits on the readout chip
 	unsigned int size();
@@ -26,11 +24,16 @@ public:
 	std::vector<bool> getChipCode();
 
 private:
+	std::vector<Hit> hitList_;
+	int rocnum_;
+
 	std::pair<int,int> getQCorePos(Hit hit);
 
 	QCore getQCoreFromHit(Hit pixel);
 
-	std::vector<QCore> organize_QCores(std::vector<QCore> qcores);
+	std::vector<QCore> organizeQCores(std::vector<QCore> qcores);
+
+	std::vector<QCore> linkQCores(std::vector<QCore> qcores);
 };
 
 #endif

--- a/DataFormats/Phase2TrackerDigi/src/Hit.cc
+++ b/DataFormats/Phase2TrackerDigi/src/Hit.cc
@@ -6,3 +6,12 @@ Hit::Hit(int row_num, int col_num, int adc_num) {
 	col_ = col_num;
 	adc_ = adc_num;
 }
+
+//Adds the input value to the adc to a max of 15 - used to combine two hits that are at the same position
+void Hit::addADC(int adc) {
+	adc_ += adc;
+
+	if(adc_ > 15) {
+		adc_ = 15;
+	}
+}

--- a/DataFormats/Phase2TrackerDigi/src/Hit.cc
+++ b/DataFormats/Phase2TrackerDigi/src/Hit.cc
@@ -15,12 +15,3 @@ void Hit::addADC(int adc) {
 		adc_ = 15;
 	}
 }
-
-//Adds the input value to the adc to a max of 15 - used to combine two hits that are at the same position
-void Hit::addADC(int adc) {
-	adc_ += adc;
-
-	if(adc_ > 15) {
-		adc_ = 15;
-	}
-}

--- a/DataFormats/Phase2TrackerDigi/src/Hit.cc
+++ b/DataFormats/Phase2TrackerDigi/src/Hit.cc
@@ -1,10 +1,10 @@
 #include "../interface/Hit.h"
 
 //Describes a hit (meant for use in 4x4 sensor coordinates) by its row number, column number, and adc value
-Hit::Hit(int row_num, int col_num, int adc_num) {
-	row_ = row_num;
-	col_ = col_num;
-	adc_ = adc_num;
+Hit::Hit(int row, int col, int adc) {
+	row_ = row;
+	col_ = col;
+	adc_ = adc;
 }
 
 //Adds the input value to the adc to a max of 15 - used to combine two hits that are at the same position

--- a/DataFormats/Phase2TrackerDigi/src/QCore.cc
+++ b/DataFormats/Phase2TrackerDigi/src/QCore.cc
@@ -28,6 +28,51 @@ QCore::QCore(int rocid, int ccol, int qcrow, bool isneighbour, bool islast, std:
   adcs_ = adcs;
 }
 
+//Returns the hitmap for the QCore in the 4x4 sensor coordinates
+std::vector<bool> QCore::getHitmap() {
+    	//assert(adcs.size()==16);
+    
+	std::vector<bool> hitmap = {};
+
+    	//hitmap.reserve(16);
+    	for(auto adc : adcs_) {
+        	hitmap.push_back(adc > 0);
+    	}
+	//assert(hitmap.size()==16);
+
+    	return toRocCoordinates(hitmap);
+}
+
+//Returns the bit code associated with the QCore
+std::vector<bool> QCore::encodeQCore(bool is_new_col) {
+	std::vector<bool> code = {};
+
+	if(is_new_col) {
+		std::vector<bool> col_code = intToBinary(ccol_, 6);
+		code.insert(code.end(), col_code.begin(), col_code.end());
+	}
+
+	code.push_back(islast_);
+	code.push_back(isneighbour_);
+
+	if(!isneighbour_) {
+		std::vector<bool> row_code = intToBinary(qcrow_, 8);
+		code.insert(code.end(), row_code.begin(), row_code.end());
+	}
+
+	std::vector<bool> hitmap_code = getHitmapCode(getHitmap());
+	code.insert(code.end(), hitmap_code.begin(), hitmap_code.end());
+
+	for(auto adc : adcs_) {
+		if(adc != 0) {
+			std::vector<bool> adc_code = intToBinary(adc, 4);
+			code.insert(code.end(), adc_code.begin(), adc_code.end());
+		}
+	}
+
+	return code;	
+}
+
 //Takes in a hitmap in sensor corrdinates with 4x4 regions and converts it to readout chip coordinates with 2x8 regions
 std::vector<bool> QCore::toRocCoordinates(std::vector<bool>& hitmap) {
 	std::vector<bool> ROC_hitmap(16, 0);
@@ -52,21 +97,6 @@ std::vector<bool> QCore::toRocCoordinates(std::vector<bool>& hitmap) {
 	}
 
 	return ROC_hitmap;
-}
-
-//Returns the hitmap for the QCore in the 4x4 sensor coordinates
-std::vector<bool> QCore::getHitmap() {
-    	//assert(adcs.size()==16);
-    
-	std::vector<bool> hitmap = {};
-
-    	//hitmap.reserve(16);
-    	for(auto adc : adcs_) {
-        	hitmap.push_back(adc > 0);
-    	}
-	//assert(hitmap.size()==16);
-
-    	return toRocCoordinates(hitmap);
 }
 
 //Converts an integer into binary, and formats it with the given length
@@ -134,34 +164,4 @@ std::vector<bool> QCore::getHitmapCode(std::vector<bool> hitmap) {
 		std::vector<bool> left_code = getHitmapCode(left_hitmap);
 		code.insert(code.end(),left_code.begin(),left_code.end());
         } return code;
-}
-
-//Returns the bit code associated with the QCore
-std::vector<bool> QCore::encodeQCore(bool is_new_col) {
-	std::vector<bool> code = {};
-
-	if(is_new_col) {
-		std::vector<bool> col_code = intToBinary(ccol_, 6);
-		code.insert(code.end(), col_code.begin(), col_code.end());
-	}
-
-	code.push_back(islast_);
-	code.push_back(isneighbour_);
-
-	if(!isneighbour_) {
-		std::vector<bool> row_code = intToBinary(qcrow_, 8);
-		code.insert(code.end(), row_code.begin(), row_code.end());
-	}
-
-	std::vector<bool> hitmap_code = getHitmapCode(getHitmap());
-	code.insert(code.end(), hitmap_code.begin(), hitmap_code.end());
-
-	for(auto adc : adcs_) {
-		if(adc != 0) {
-			std::vector<bool> adc_code = intToBinary(adc, 4);
-			code.insert(code.end(), adc_code.begin(), adc_code.end());
-		}
-	}
-
-	return code;	
 }

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/PixelQCoreProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/PixelQCoreProducer.cc
@@ -126,26 +126,76 @@ std::vector<Hit> adjustEdges(std::vector<Hit> hitList) {
         std::vector<Hit> hitListOne = {};
         std::vector<Hit> hitListTwo = {};
 
+	bool hit_already_exists;
+
         for(auto hit:hitList) {
-                if(hit.row() < 672) {
+                if(hit.row() < 671) {
                         hitListOne.push_back(hit);
-                } else if(672 <= hit.row() && hit.row() <= 675) {
-                        hitListOne.push_back(Hit(671, hit.col(), hit.adc()));
-                } else if(676 <= hit.row() && hit.row() <= 679) {
-                        hitListOne.push_back(Hit(672, hit.col(), hit.adc()));
-                } else if(hit.row() > 679) {
+                } else if(671 <= hit.row() && hit.row() <= 675) {
+			hit_already_exists = false;
+
+			for(auto other_hit : hitListOne) {
+				if(other_hit.row() == 671 && other_hit.col() == hit.col()) {
+					other_hit.addADC(hit.adc());
+					hit_already_exists = true;
+				}
+			}
+
+			if(!hit_already_exists) {
+                        	hitListOne.push_back(Hit(671, hit.col(), hit.adc()));
+			}
+
+                } else if(676 <= hit.row() && hit.row() <= 680) {
+			hit_already_exists = false;
+
+			for(auto other_hit : hitListOne) {
+				if(other_hit.row() == 672 && other_hit.col() == hit.col()) {
+					other_hit.addADC(hit.adc());
+					hit_already_exists = true;
+				}
+			}
+
+			if(!hit_already_exists) {
+                        	hitListOne.push_back(Hit(672, hit.col(), hit.adc()));
+			}
+
+                } else if(hit.row() > 680) {
                         hitListOne.push_back(Hit(hit.row() - 8, hit.col(), hit.adc()));
                 }
         }
 
         for(auto hit:hitListOne) {
-                if(hit.col() < 216) {
+                if(hit.col() < 215) {
                         hitListTwo.push_back(hit);
-                } else if(hit.col() == 216) {
-                        hitListTwo.push_back(Hit(hit.row(), 215, hit.adc()));
-                } else if(hit.col() == 217) {
-                        hitListTwo.push_back(Hit(hit.row(), 216, hit.adc()));
-                } else if(hit.col() > 217) {
+                } else if(215 <= hit.col() && hit.col() <= 216) {
+			hit_already_exists = false;
+
+			for(auto other_hit : hitListTwo) {
+				if(other_hit.row() == hit.row() && other_hit.col() == 215) {
+					other_hit.addADC(hit.adc());
+					hit_already_exists = true;
+				}
+			}
+
+			if(!hit_already_exists) {
+                        	hitListTwo.push_back(Hit(hit.row(), 215, hit.adc()));
+			}
+
+                } else if(217 <= hit.col() && hit.col() <= 218) {
+			hit_already_exists = false;
+
+			for(auto other_hit : hitListTwo) {
+				if(other_hit.row() == hit.row() && other_hit.col() == 216) {
+					other_hit.addADC(hit.adc());
+					hit_already_exists = true;
+				}
+			}
+
+			if(!hit_already_exists) {
+                        	hitListTwo.push_back(Hit(hit.row(), 216, hit.adc()));
+			}
+
+                } else if(hit.col() > 218) {
                         hitListTwo.push_back(Hit(hit.row(), hit.col() - 2, hit.adc()));
                 }
         }

--- a/EventFilter/Phase2TrackerRawToDigi/test/plugins/Phase2PixelQCoreNtuple.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/test/plugins/Phase2PixelQCoreNtuple.cc
@@ -405,7 +405,7 @@ void Phase2PixelQCoreNtuple::analyze(const edm::Event& e, const edm::EventSetup&
     for ( auto iterBitStream = theBitStreams.begin();
           iterBitStream != theBitStreams.end();
           ++iterBitStream ) {
-      std::cout << "BITSTREAM : " << iterBitStream->get_rocid() << " size = " << iterBitStream->get_bitstream().size() << std::endl;
+      std::cout << "BITSTREAM : " << iterBitStream->rocid() << " size = " << iterBitStream->bitstream().size() << std::endl;
     }
   }
 

--- a/EventFilter/Phase2TrackerRawToDigi/test/plugins/Phase2PixelQCoreNtupleAltered.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/test/plugins/Phase2PixelQCoreNtupleAltered.cc
@@ -405,7 +405,7 @@ void Phase2PixelQCoreNtupleAltered::analyze(const edm::Event& e, const edm::Even
     for ( auto iterBitStream = theBitStreams.begin();
           iterBitStream != theBitStreams.end();
           ++iterBitStream ) {
-      std::cout << "BITSTREAM : " << iterBitStream->get_rocid() << " size = " << iterBitStream->get_bitstream().size() << std::endl;
+      std::cout << "BITSTREAM : " << iterBitStream->rocid() << " size = " << iterBitStream->bitstream().size() << std::endl;
     }
   }
 

--- a/EventFilter/Phase2TrackerRawToDigi/test/plugins/Phase2PixelRawNtuple.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/test/plugins/Phase2PixelRawNtuple.cc
@@ -406,7 +406,7 @@ void Phase2PixelRawNtuple::analyze(const edm::Event& e, const edm::EventSetup& e
     for ( auto iterBitStream = theBitStreams.begin();
           iterBitStream != theBitStreams.end();
           ++iterBitStream ) {
-      std::cout << "BITSTREAM : " << iterBitStream->get_rocid() << " size = " << iterBitStream->get_bitstream().size() << std::endl;
+      std::cout << "BITSTREAM : " << iterBitStream->rocid() << " size = " << iterBitStream->bitstream().size() << std::endl;
     }
   }
 


### PR DESCRIPTION
#### PR description:

@aryd @Roh-coder
Changed the ways that hits on the edges of ROCs are dealt with so that hits which are mapped to the same pixel are combined by adding their adc values to a maximum of 15. Also, finished going through list of cms coding conventions and updating code to match them.

#### PR validation:

Tested that code compiled and ran, and ran with test cases to make sure worked as expected.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
