### PR TITLE
Aurora Formatting

### DIFF
--- a/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
+++ b/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
@@ -41,6 +41,8 @@ private:
 	void auroraFormat(std::vector<bool>& code);
 
 	void addOrphanBits(std::vector<bool>& code);
+
+	void addAuroraTags(std::vector<bool>& code);
 };
 
 #endif

--- a/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
+++ b/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
@@ -21,7 +21,7 @@ public:
 
 	std::vector<QCore> getOrganizedQCores();
 
-	std::vector<bool> getChipCode(int event);
+	std::vector<bool> getChipCode(int event, bool aurora);
 
 private:
 	std::vector<Hit> hitList_;
@@ -36,6 +36,10 @@ private:
 	std::vector<QCore> linkQCores(std::vector<QCore> qcores);
   
 	std::vector<bool> intToBinary(int num, int length);
+
+	void auroraFormat(std::vector<bool>& code);
+
+	void addOrphanBits(std::vector<bool>& code);
 };
 
 #endif

--- a/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
+++ b/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
@@ -21,7 +21,7 @@ public:
 
 	std::vector<QCore> getOrganizedQCores();
 
-	std::vector<bool> getChipCode();
+	std::vector<bool> getChipCode(int event);
 
 private:
 	std::vector<Hit> hitList_;
@@ -34,6 +34,8 @@ private:
 	std::vector<QCore> organizeQCores(std::vector<QCore> qcores);
 
 	std::vector<QCore> linkQCores(std::vector<QCore> qcores);
+  
+	std::vector<bool> intToBinary(int num, int length);
 };
 
 #endif

--- a/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
+++ b/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
@@ -40,6 +40,8 @@ private:
 
 	void auroraFormat(std::vector<bool>& code);
 
+	void addEndStreamBits(std::vector<bool>& code);
+
 	void addOrphanBits(std::vector<bool>& code);
 
 	void addAuroraTags(std::vector<bool>& code);

--- a/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
+++ b/DataFormats/Phase2TrackerDigi/interface/ReadoutChip.h
@@ -26,6 +26,7 @@ public:
 private:
 	std::vector<Hit> hitList_;
 	int rocnum_;
+	static bool endOfStreamMarker;
 
 	std::pair<int,int> getQCorePos(Hit hit);
 

--- a/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
+++ b/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
@@ -7,6 +7,8 @@
 #include "../interface/ReadoutChip.h"
 #include "../interface/Hit.h"
 
+bool ReadoutChip::endOfStreamMarker = true;
+
 ReadoutChip::ReadoutChip(int rocnum, std::vector<Hit> hitList) {
   hitList_ = hitList;
   rocnum_ = rocnum; 
@@ -178,10 +180,16 @@ void ReadoutChip::auroraFormat(std::vector<bool>& code) {
 //Takes in an encoding and makes its length equal to the nearest multiple of 64
 //above its current length by adding 0's to the end of the code
 void ReadoutChip::addOrphanBits(std::vector<bool>& code) {
-	//std::vector<bool> orphanBits(code.size() % 64, 0);
-	//code.insert(code.end(), orphanBits.begin(), orphanBits.end());
-	
+	int trailingZeros = 0;
+
 	while(code.size() % 64 != 0) {
 		code.push_back(0);
+		trailingZeros++;
+	}
+
+	if(endOfStreamMarker && trailingZeros < 6) {
+		for(int i = 0; i < 64; i++) {
+			code.push_back(0);
+		}
 	}
 }

--- a/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
+++ b/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
@@ -174,8 +174,21 @@ std::vector<bool> ReadoutChip::intToBinary(int num, int length) {
 
 //Takes in an unformatted encoding and adds aurora formatting to it
 void ReadoutChip::auroraFormat(std::vector<bool>& code) {
+	addEndStreamBits(code);
 	addOrphanBits(code);
 	addAuroraTags(code);
+}
+
+//Takes in a code that is to be aurora formatted and adds a 1 at the beginning of
+//the last 64-bit block and a 0 at the beginning of each previous 64-bit block
+void ReadoutChip::addEndStreamBits(std::vector<bool>& code) {
+	for(size_t i = 0; i < code.size(); i += 64) {
+		if(code.size() - i < 64) {
+			code.insert(code.begin() + i, 1);
+		} else {
+			code.insert(code.begin() + i, 0);
+		}
+	}
 }
 
 //Takes in an encoding and makes its length equal to the nearest multiple of 64

--- a/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
+++ b/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <vector>
 #include <utility>
 #include <string>
@@ -41,8 +42,8 @@ std::vector<QCore> ReadoutChip::getOrganizedQCores() {
 }
 
 //Returns the encoding of the readout chip
-std::vector<bool> ReadoutChip::getChipCode() {
-        std::vector<bool> code = {};
+std::vector<bool> ReadoutChip::getChipCode(int event) {
+        std::vector<bool> code = intToBinary(event, 8);
 
         if(hitList_.size() > 0) {
                 std::vector<QCore> qcores = getOrganizedQCores();
@@ -142,4 +143,25 @@ std::vector<QCore> ReadoutChip::linkQCores(std::vector<QCore> qcores) {
 	std::cout << "Here003" << std::endl;
 
 	return qcores;
+}
+
+//Converts an integer into binary, and formats it with the given length
+std::vector<bool> ReadoutChip::intToBinary(int num, int length) {
+	int n = num;
+	std::vector<bool> bi_num = {};
+	
+	for(int i = 0; i < length; i++) {
+		bi_num.push_back(0);
+	}
+
+	for(int i = length; i > 0; i--) {
+		if(n >= pow(2, i - 1)) {
+			bi_num[length - i] = 1;
+			n -= pow(2,i - 1);
+		} else {
+			bi_num[length - i] = 0;
+		}
+	}
+
+	return bi_num;
 }

--- a/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
+++ b/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
@@ -178,6 +178,10 @@ void ReadoutChip::auroraFormat(std::vector<bool>& code) {
 //Takes in an encoding and makes its length equal to the nearest multiple of 64
 //above its current length by adding 0's to the end of the code
 void ReadoutChip::addOrphanBits(std::vector<bool>& code) {
-	std::vector<bool> orphanBits(code.size() % 64, 0);
-	code.insert(code.end(), orphanBits.begin(), orphanBits.end());
+	//std::vector<bool> orphanBits(code.size() % 64, 0);
+	//code.insert(code.end(), orphanBits.begin(), orphanBits.end());
+	
+	while(code.size() % 64 != 0) {
+		code.push_back(0);
+	}
 }

--- a/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
+++ b/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
@@ -42,7 +42,7 @@ std::vector<QCore> ReadoutChip::getOrganizedQCores() {
 }
 
 //Returns the encoding of the readout chip
-std::vector<bool> ReadoutChip::getChipCode(int event) {
+std::vector<bool> ReadoutChip::getChipCode(int event, bool aurora) {
         std::vector<bool> code = intToBinary(event, 8);
 
         if(hitList_.size() > 0) {
@@ -57,6 +57,10 @@ std::vector<bool> ReadoutChip::getChipCode(int event) {
 			is_new_col = qcore.islast();
                 }
         }
+
+	if(aurora) {
+		auroraFormat(code);
+	}
 
         return code;
 }
@@ -164,4 +168,16 @@ std::vector<bool> ReadoutChip::intToBinary(int num, int length) {
 	}
 
 	return bi_num;
+}
+
+//Takes in an unformatted encoding and adds aurora formatting to it
+void ReadoutChip::auroraFormat(std::vector<bool>& code) {
+	addOrphanBits(code);
+}
+
+//Takes in an encoding and makes its length equal to the nearest multiple of 64
+//above its current length by adding 0's to the end of the code
+void ReadoutChip::addOrphanBits(std::vector<bool>& code) {
+	std::vector<bool> orphanBits(code.size() % 64, 0);
+	code.insert(code.end(), orphanBits.begin(), orphanBits.end());
 }

--- a/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
+++ b/DataFormats/Phase2TrackerDigi/src/ReadoutChip.cc
@@ -175,6 +175,7 @@ std::vector<bool> ReadoutChip::intToBinary(int num, int length) {
 //Takes in an unformatted encoding and adds aurora formatting to it
 void ReadoutChip::auroraFormat(std::vector<bool>& code) {
 	addOrphanBits(code);
+	addAuroraTags(code);
 }
 
 //Takes in an encoding and makes its length equal to the nearest multiple of 64
@@ -191,5 +192,12 @@ void ReadoutChip::addOrphanBits(std::vector<bool>& code) {
 		for(int i = 0; i < 64; i++) {
 			code.push_back(0);
 		}
+	}
+}
+
+//Takes in a code that has had orphan bits added and adds the aurora tag 01 in front of each 64 bit block
+void ReadoutChip::addAuroraTags(std::vector<bool>& code) {
+	for(size_t i = 0; i < code.size(); i += 66) {
+		code.insert(code.begin() + i, {0,1});
 	}
 }

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/PixelQCoreProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/PixelQCoreProducer.cc
@@ -238,7 +238,7 @@ std::vector<ReadoutChip> splitByChip(std::vector<Hit> hitList) {
         return {ReadoutChip(0,chip1), ReadoutChip(1, chip2), ReadoutChip(2, invertHits(chip3)),ReadoutChip(3, invertHits(chip4))};
 }
 
-std::vector<ReadoutChip> processHits(std::vector<Hit> hitList, int event) {
+std::vector<ReadoutChip> processHits(std::vector<Hit> hitList, int event, bool auroraFormat) {
         std::vector<Hit> newHitList;
 
         std::cout << "Hits:" << "\n";
@@ -253,7 +253,7 @@ std::vector<ReadoutChip> processHits(std::vector<Hit> hitList, int event) {
 
         for(size_t i = 0; i < chips.size(); i++) {
                 ReadoutChip chip = chips[i];
-                code = chip.getChipCode(event);
+                code = chip.getChipCode(event, auroraFormat);
 
                 std::cout << "number of hits: " << chip.size() << "\n";
                 std::cout << "code length: " << code.size() << "\n";
@@ -302,6 +302,8 @@ void PixelQCoreProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
 
     int eventNum = 1;
 
+    bool auroraFormat = true;
+
 
 
     //break;
@@ -332,7 +334,7 @@ void PixelQCoreProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
       hitlist.emplace_back(Hit(iterDigi->row(),iterDigi->column(),iterDigi->adc()));
     }
 
-    std::vector<ReadoutChip> chips = processHits(hitlist, eventNum);
+    std::vector<ReadoutChip> chips = processHits(hitlist, eventNum, auroraFormat);
 
     std::cout << "Make DetSet" << std::endl;
 
@@ -356,7 +358,7 @@ void PixelQCoreProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
 	DetSetQCores.push_back(qcore);
       }
 
-      ROCBitStream aROCBitStream(i,chip.getChipCode(eventNum));
+      ROCBitStream aROCBitStream(i,chip.getChipCode(eventNum, auroraFormat));
 
       DetSetBitStream.push_back(aROCBitStream);
 

--- a/EventFilter/Phase2TrackerRawToDigi/plugins/PixelQCoreProducer.cc
+++ b/EventFilter/Phase2TrackerRawToDigi/plugins/PixelQCoreProducer.cc
@@ -238,7 +238,7 @@ std::vector<ReadoutChip> splitByChip(std::vector<Hit> hitList) {
         return {ReadoutChip(0,chip1), ReadoutChip(1, chip2), ReadoutChip(2, invertHits(chip3)),ReadoutChip(3, invertHits(chip4))};
 }
 
-std::vector<ReadoutChip> processHits(std::vector<Hit> hitList) {
+std::vector<ReadoutChip> processHits(std::vector<Hit> hitList, int event) {
         std::vector<Hit> newHitList;
 
         std::cout << "Hits:" << "\n";
@@ -253,7 +253,7 @@ std::vector<ReadoutChip> processHits(std::vector<Hit> hitList) {
 
         for(size_t i = 0; i < chips.size(); i++) {
                 ReadoutChip chip = chips[i];
-                code = chip.getChipCode();
+                code = chip.getChipCode(event);
 
                 std::cout << "number of hits: " << chip.size() << "\n";
                 std::cout << "code length: " << code.size() << "\n";
@@ -300,6 +300,8 @@ void PixelQCoreProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
 
     edm::DetSet<PixelDigi> theDigis = (*pixelDigiHandle)[ tkId ];
 
+    int eventNum = 1;
+
 
 
     //break;
@@ -330,7 +332,7 @@ void PixelQCoreProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
       hitlist.emplace_back(Hit(iterDigi->row(),iterDigi->column(),iterDigi->adc()));
     }
 
-    std::vector<ReadoutChip> chips = processHits(hitlist);
+    std::vector<ReadoutChip> chips = processHits(hitlist, eventNum);
 
     std::cout << "Make DetSet" << std::endl;
 
@@ -354,7 +356,7 @@ void PixelQCoreProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
 	DetSetQCores.push_back(qcore);
       }
 
-      ROCBitStream aROCBitStream(i,chip.getChipCode());
+      ROCBitStream aROCBitStream(i,chip.getChipCode(eventNum));
 
       DetSetBitStream.push_back(aROCBitStream);
 


### PR DESCRIPTION
#### PR description:
@aryd @Roh-coder 
Added the ability to have the bitstream encodings be aurora formatted, which is can be turned on or off by a boolean in the producer. Since it was decided that it would not make sense to simulate the service bits, the aurora formatting in the simulation primarily just adds the orphan bit padding to make sure that the length of the code is a multiple of 64.

#### PR validation:
Checked that code compiled and ran properly, and examined the codes generated to make sure that they were coming out with lengths as multiples of 64 as expected.

#### if this PR is a backport please specify the original PR and why you need to backport that PR:

<!-- Please replace this text with any link to  -->

Before submitting your pull requests, make sure you followed this checklist:
- verify that the PR is really intended for the chosen branch
- verify that changes follow [CMS Naming, Coding, And Style Rules](http://cms-sw.github.io/cms_coding_rules.html)
- verify that the PR passes the basic test procedure suggested in the [CMSSW PR instructions](https://cms-sw.github.io/PRWorkflow.html)
